### PR TITLE
Use consistent client from jumpstarter side to trigger the pipelines.

### DIFF
--- a/tf-api/api.py
+++ b/tf-api/api.py
@@ -114,7 +114,7 @@ class CustomHandler(BaseHTTPRequestHandler):
                     #{'name': 'board', 'value': data['environments'][0]['variables'].get('HW_TARGET', '')},
                     {'name': 'board', 'value': 'rcar-29'},
                     {'name': 'skipProvisioning', 'value': 'true'}, #TODO 
-                    {'name': 'clientName', 'value': f"tc-{run_id}"},
+                    {'name': 'clientName', 'value': 'demo'}, #TODO
                     {'name': 'timeout', 'value': data['settings']['pipeline'].get('timeout', '')},
                     {'name': 'ctx', 'value': dict(data['environments'][0]['tmt']['context'])},
                     {'name': 'env', 'value': dict(data['environments'][0]['tmt']['environment'])},


### PR DESCRIPTION
The jumpstarter client should be used similarly to how CI is triggered, we don’t need to create a new client for each run instead, we can rely on the pipeline’s run_id to link back to the triggering user.